### PR TITLE
ダークテーマ時のバグ修正

### DIFF
--- a/src/minisakai.ts
+++ b/src/minisakai.ts
@@ -392,7 +392,7 @@ const overwritecolor = function (className: string, color: string | undefined) {
   const element = document.getElementsByClassName(className);
   for (let i = 0; i < element.length; i++) {
     const elem = element[i] as HTMLElement;
-    elem.setAttribute("style", "color:" + color + "!important");
+    elem.setAttribute("style", elem.getAttribute("style") + ";color:" + color + "!important");
   }
 };
 


### PR DESCRIPTION
## Description
PandAの設定がダークテーマの時に，`miniPandA`でupdate系が走る操作をすると別のタブのアイテムが見えてしまう不具合の修正

## Type of change

- [x] バグ修正

## Levels of review
- [x] Level1: 即ApproveしてOK