### PR TITLE
課題の提出期限による色分けの基準を変更できるようにした

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -33,13 +33,51 @@
       "time": { "content": "$2" }
     }
   },
+
+  "settings_colors_danger": { "message": "【$color_type$】 due is very soon",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_warning": { "message": "【$color_type$】 due is soon",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_middle": { "message": "【$color_type$】 due is a little soon",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_later": { "message": "【$color_type$】 due is later",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+
   "assignment_acquisition_date": {"message": "Assignment Acquisition Date: "},
   "testquiz_acquisition_date": {"message": "Test&Quiz Acquisition Date: "},
-  "due24h": {"message": "Due within 24hrs"},
-  "due5d": {"message": "Due within 5days"},
-  "due14d": {"message": "Due within 14days"},
+  "dueVerySoon": {"message": "$time$ hours before due",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueSoon": {"message": "$time$ days before due",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueMiddle": {"message": "$time$ days before due",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueLater": {"message": "More than $time$ days before due",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
   "duePassed": {"message": "Late submission possible"},
-  "dueOver14d": {"message": "Others"},
   "checked": {"message": "Submitted"},
   "no_available_assignments": {"message": "There are no available assignments :)"},
   "remain_time": { "message": "$days$d, $hours$hr, $minutes$min left.",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -15,6 +15,7 @@
   "settings_color_checked_item": {"message": "チェック済の課題も色付けする"},
   "settings_display_late_submit_assignment": {"message": "遅延提出可能な課題を表示する"},
   "settings_reset_colors": {"message": "デフォルト色に戻す"},
+  
   "settings_colors_hour": { "message": "【$color_type$】 締切$time$時間前",
     "placeholders": {
       "color_type": { "content": "$1" },
@@ -33,13 +34,53 @@
       "time": { "content": "$2" }
     }
   },
+
+  "settings_colors_danger": { "message": "【$color_type$】 締切直前の課題",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_warning": { "message": "【$color_type$】 締切の近い課題",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_middle": { "message": "【$color_type$】 締切のやや近い課題",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+  "settings_colors_later": { "message": "【$color_type$】 締切の遠い課題",
+    "placeholders": {
+      "color_type": { "content": "$1" }
+    }
+  },
+
   "assignment_acquisition_date": {"message": "課題取得日時: "},
   "testquiz_acquisition_date": {"message": "クイズ取得日時: "},
-  "due24h": {"message": "締め切り２４時間以内"},
-  "due5d": {"message": "締め切り５日以内"},
-  "due14d": {"message": "締め切り１４日以内"},
+
+  "dueVerySoon": {"message": "締め切り$time$時間以内",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueSoon": {"message": "締め切り$time$日以内",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueMiddle": {"message": "締め切り$time$日以内",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
+  "dueLater": {"message": "締め切りまで$time$日以上",
+    "placeholders": {
+      "time": { "content": "$1" }
+    }
+  },
   "duePassed": {"message": "遅延提出可能"},
-  "dueOver14d": {"message": "その他"},
+  "dueOther": {"message": "その他"},
   "checked": {"message": "提出済み"},
   "no_available_assignments": {"message": "表示できる課題はないよ"},
   "remain_time": { "message": "あと$days$日$hours$時間$minutes$分",
@@ -55,5 +96,8 @@
     "placeholders": {
       "name": { "content": "$1" }
     }
-  }
+  },
+  "settings_assignment_danger_hours": {"message": "締め切り直前の課題の基準 [時間]"},
+  "settings_assignment_warning_days": {"message": "締め切りが近い課題の基準 [日]"},
+  "settings_assignment_middle_days": {"message": "締め切りがやや近い課題の基準 [日]"}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfortable-panda",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Comfortable PandA is a browser extension for managing assignments and quizzes on PandA.",
   "main": "index.ts",
   "scripts": {

--- a/src/components/entryTab.tsx
+++ b/src/components/entryTab.tsx
@@ -5,7 +5,7 @@ import { Memo, MemoEntry } from "../features/entity/memo/types";
 import { Quiz, QuizEntry } from "../features/entity/quiz/types";
 import { getDaysUntil } from "../utils";
 import AssignmentEntryView from "./assignment";
-import { useTranslation } from "./helper";
+import { useTranslation, useTranslationArgsDeps, useTranslationDeps } from "./helper";
 import MemoEntryView from "./memo";
 import QuizEntryView from "./quiz";
 import { CurrentTime, MaxTimestamp } from "../constant";
@@ -118,28 +118,32 @@ export function EntryTab(props: {
                 });
                 continue;
             }
-            const daysUntilDue = getDaysUntil(CurrentTime, entry.getDueDate(props.settings.miniSakaiOption.showLateAcceptedEntry));
+            const daysUntilDue = getDaysUntil(props.settings, CurrentTime, entry.getDueDate(props.settings.miniSakaiOption.showLateAcceptedEntry));
 
             switch (daysUntilDue) {
-                case "due24h":
+                //case "due24h":
+                case "dueVerySoon":
                     dangerElements.push({
                         entry: entry,
                         course: course
                     });
                     break;
-                case "due5d":
+                //case "due5d":
+                case "dueSoon":
                     warningElements.push({
                         entry: entry,
                         course: course
                     });
                     break;
-                case "due14d":
+                //case "due14d":
+                case "dueMiddle":
                     successElements.push({
                         entry: entry,
                         course: course
                     });
                     break;
-                case "dueOver14d":
+                //case "dueOver14d":
+                case "dueLater":
                     otherElements.push({
                         entry: entry,
                         course: course
@@ -161,7 +165,7 @@ export function EntryTab(props: {
 
             {dangerElements.length === 0 ? null : (
                 <>
-                    <MiniSakaiEntryHeader dueType="danger" />
+                    <MiniSakaiEntryHeader dueType="danger" settings={props.settings} />
                     <MiniSakaiEntryList
                         dueType="danger"
                         isSubset={props.isSubset}
@@ -174,7 +178,7 @@ export function EntryTab(props: {
             )}
             {warningElements.length === 0 ? null : (
                 <>
-                    <MiniSakaiEntryHeader dueType="warning" />
+                    <MiniSakaiEntryHeader dueType="warning" settings={props.settings} />
                     <MiniSakaiEntryList
                         dueType="warning"
                         isSubset={props.isSubset}
@@ -187,7 +191,7 @@ export function EntryTab(props: {
             )}
             {successElements.length === 0 ? null : (
                 <>
-                    <MiniSakaiEntryHeader dueType="success" />
+                    <MiniSakaiEntryHeader dueType="success" settings={props.settings} />
                     <MiniSakaiEntryList
                         dueType="success"
                         isSubset={props.isSubset}
@@ -200,7 +204,7 @@ export function EntryTab(props: {
             )}
             {otherElements.length === 0 ? null : (
                 <>
-                    <MiniSakaiEntryHeader dueType="other" />
+                    <MiniSakaiEntryHeader dueType="other" settings={props.settings} />
                     <MiniSakaiEntryList
                         dueType="other"
                         isSubset={props.isSubset}
@@ -213,7 +217,7 @@ export function EntryTab(props: {
             )}
             {checkedElements.length === 0 ? null : (
                 <>
-                    <MiniSakaiEntryHeader dueType="checked" />
+                    <MiniSakaiEntryHeader dueType="checked" settings={props.settings} />
                     <MiniSakaiEntryList
                         dueType="checked"
                         isSubset={props.isSubset}
@@ -325,14 +329,14 @@ function AddMemoBox(props: { shown: boolean; courses: Course[]; onMemoAdd: (memo
     );
 }
 
-function MiniSakaiEntryHeader(props: { dueType: DueType }) {
+function MiniSakaiEntryHeader(props: { dueType: DueType, settings: Settings }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const dueTypeTitleMap: { [key in DueType]: string } = {
         checked: useTranslation("checked"),
-        danger: useTranslation("due24h"),
-        warning: useTranslation("due5d"),
-        success: useTranslation("due14d"),
-        other: useTranslation("dueOver14d")
+        danger: useTranslationArgsDeps("dueVerySoon", [props.settings.timeUntilDeadline.dangerHours.toString()], []),
+        warning: useTranslationArgsDeps("dueSoon", [props.settings.timeUntilDeadline.warningDays.toString()], []),
+        success: useTranslationArgsDeps("dueMiddle", [props.settings.timeUntilDeadline.middleDays.toString()], []),
+        other: useTranslationArgsDeps("dueLater", [props.settings.timeUntilDeadline.middleDays.toString()], []),
     };
     const className = useMemo(() => {
         return `cs-minisakai-${props.dueType}`;

--- a/src/components/favoritesBar.ts
+++ b/src/components/favoritesBar.ts
@@ -4,10 +4,10 @@ import { EntityProtocol, EntryProtocol } from "../features/entity/type";
 import { MaxTimestamp } from "../constant";
 
 const dueCategoryClassMap: { [key in DueCategory]: string } = {
-    due24h: "cs-tab-danger",
-    due5d: "cs-tab-warning",
-    due14d: "cs-tab-success",
-    dueOver14d: "cs-tab-other",
+    dueVerySoon: "cs-tab-danger",
+    dueSoon: "cs-tab-warning",
+    dueMiddle: "cs-tab-success",
+    dueLater: "cs-tab-other",
     duePassed: ""
 };
 
@@ -34,7 +34,7 @@ const createDueMap = (settings: Settings, courseMap: CourseMap): DueMap => {
         if (entries.entries.length === 0) continue;
         const closestTime = getClosestTime(settings, entries.entries);
         if (closestTime === MaxTimestamp) continue;
-        const daysUntilDue = getDaysUntil(settings.appInfo.currentTime, closestTime);
+        const daysUntilDue = getDaysUntil(settings, settings.appInfo.currentTime, closestTime);
         dueMap.set(courseID, { due: daysUntilDue, isRead: entries.isRead });
     }
     return dueMap;
@@ -65,8 +65,10 @@ export async function createFavoritesBar(settings: Settings, entities: EntityPro
         const tabClass = dueCategoryClassMap[courseInfo.due];
         const aTagCount = defaultTab[j].getElementsByTagName("a").length;
         // Apply color to course button
-        for (let i = 0; i < aTagCount; i++) {
-            defaultTab[j].getElementsByTagName("a")[i].classList.add(tabClass);
+        if(tabClass !== "") {   // If not duePassed
+            for (let i = 0; i < aTagCount; i++) {
+                defaultTab[j].getElementsByTagName("a")[i].classList.add(tabClass);
+            }
         }
         defaultTab[j].classList.add(tabClass);
         // Put notification badge

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -25,15 +25,15 @@ export type SettingsChange =
 export function SettingsTab(props: { onSettingsChange: (change: SettingsChange) => void; settings: Settings }) {
     const settings = props.settings;
 
-    const topColorDangerDesc = useTranslationArgsDeps("settings_colors_hour", ["Tab Bar", "24"], []);
-    const topColorWarningDesc = useTranslationArgsDeps("settings_colors_day", ["Tab Bar", "5"], []);
-    const topColorSuccessDesc = useTranslationArgsDeps("settings_colors_day", ["Tab Bar", "14"], []);
-    const topColorOtherDesc = useTranslationArgsDeps("settings_colors_day_more", ["Tab Bar", "14"], []);
+    const topColorDangerDesc = useTranslationArgsDeps("settings_colors_danger", ["Tab Bar"], []);
+    const topColorWarningDesc = useTranslationArgsDeps("settings_colors_warning", ["Tab Bar"], []);
+    const topColorSuccessDesc = useTranslationArgsDeps("settings_colors_middle", ["Tab Bar"], []);
+    const topColorOtherDesc = useTranslationArgsDeps("settings_colors_later", ["Tab Bar"], []);
 
-    const miniColorDangerDesc = useTranslationArgsDeps("settings_colors_hour", ["miniPandA", "24"], []);
-    const miniColorWarningDesc = useTranslationArgsDeps("settings_colors_day", ["miniPandA", "5"], []);
-    const miniColorSuccessDesc = useTranslationArgsDeps("settings_colors_day", ["miniPandA", "14"], []);
-    const miniColorOtherDesc = useTranslationArgsDeps("settings_colors_day_more", ["miniPandA", "14"], []);
+    const miniColorDangerDesc = useTranslationArgsDeps("settings_colors_danger", ["miniPandA"], []);
+    const miniColorWarningDesc = useTranslationArgsDeps("settings_colors_warning", ["miniPandA"], []);
+    const miniColorSuccessDesc = useTranslationArgsDeps("settings_colors_middle", ["miniPandA"], []);
+    const miniColorOtherDesc = useTranslationArgsDeps("settings_colors_later", ["miniPandA"], []);
 
     return (
         <div className="cs-settings-tab">
@@ -94,6 +94,45 @@ export function SettingsTab(props: { onSettingsChange: (change: SettingsChange) 
                 }
             />
 
+            <TranslatedNumberItem
+                descriptionTag="settings_assignment_danger_hours"
+                value={settings.timeUntilDeadline.dangerHours}
+                min={1}
+                max={settings.timeUntilDeadline.warningDays * 24 - 1}
+                onChange={(v) =>
+                    props.onSettingsChange({
+                        type: "number",
+                        id: "timeUntilDeadline.dangerHours",
+                        newValue: v
+                    })
+                }
+            />
+            <TranslatedNumberItem
+                descriptionTag="settings_assignment_warning_days"
+                value={settings.timeUntilDeadline.warningDays}
+                min={settings.timeUntilDeadline.dangerHours / 24}
+                max={settings.timeUntilDeadline.middleDays - 1}
+                onChange={(v) =>
+                    props.onSettingsChange({
+                        type: "number",
+                        id: "timeUntilDeadline.warningDays",
+                        newValue: v
+                    })
+                }
+            />
+            <TranslatedNumberItem
+                descriptionTag="settings_assignment_middle_days"
+                value={settings.timeUntilDeadline.middleDays}
+                min={settings.timeUntilDeadline.warningDays + 1}
+                onChange={(v) =>
+                    props.onSettingsChange({
+                        type: "number",
+                        id: "timeUntilDeadline.middleDays",
+                        newValue: v
+                    })
+                }
+            />
+
             <StringItem
                 description={topColorDangerDesc}
                 value={settings.color.topDanger}
@@ -105,6 +144,7 @@ export function SettingsTab(props: { onSettingsChange: (change: SettingsChange) 
                     })
                 }
             />
+
             <StringItem
                 description={topColorWarningDesc}
                 value={settings.color.topWarning}
@@ -116,6 +156,7 @@ export function SettingsTab(props: { onSettingsChange: (change: SettingsChange) 
                     })
                 }
             />
+
             <StringItem
                 description={topColorSuccessDesc}
                 value={settings.color.topSuccess}
@@ -127,6 +168,7 @@ export function SettingsTab(props: { onSettingsChange: (change: SettingsChange) 
                     })
                 }
             />
+
             <StringItem
                 description={topColorOtherDesc}
                 value={settings.color.topOther}
@@ -241,6 +283,9 @@ function NumberItem(props: {
     description: string;
     display?: boolean;
     value: number;
+    min?: number;
+    max?: number;
+    isInteger?: boolean;
     onChange: (newValue: number) => void;
 }) {
     return (
@@ -249,6 +294,9 @@ function NumberItem(props: {
                 type="number"
                 className="cp-settings-inputbox"
                 value={props.value}
+                min={props.min}
+                max={props.max}
+                step={props.isInteger ? 1 : undefined}
                 onChange={(ev) => props.onChange(parseInt(ev.target.value))}
             ></input>
         </SettingsItem>
@@ -259,11 +307,16 @@ function TranslatedNumberItem(props: {
     descriptionTag: string;
     display?: boolean;
     value: number;
+    min?: number;
+    max?: number;
+    isInteger?: boolean;
     onChange: (newValue: number) => void;
 }) {
     const description = useTranslationDeps(props.descriptionTag, [props.descriptionTag]);
     return (
-        <NumberItem description={description} display={props.display} value={props.value} onChange={props.onChange} />
+        <NumberItem description={description} display={props.display} value={props.value} onChange={props.onChange} 
+            min={props.min} max={props.max} isInteger={props.isInteger}
+        />
     );
 }
 

--- a/src/features/setting/decode.ts
+++ b/src/features/setting/decode.ts
@@ -7,6 +7,7 @@ export const decodeSettings = (data: any): Settings => {
     settings.fetchTime = data.fetchTime;
     settings.cacheInterval = data.cacheInterval;
     settings.miniSakaiOption = data.miniSakaiOption;
+    settings.timeUntilDeadline = data.timeUntilDeadline;
     // For backward compatibility
     for (const colorName of Object.getOwnPropertyNames(settings.color)) {
         if (typeof data.color[colorName] !== "undefined") {

--- a/src/features/setting/types.ts
+++ b/src/features/setting/types.ts
@@ -34,6 +34,12 @@ type CSColor = {
     miniOther: string;
 };
 
+type SettingsTimeUntilDeadline = {
+    dangerHours: number;
+    warningDays: number;
+    middleDays: number;
+}
+
 const CSTheme = {
     light: { textColor: "#464646", bgColor: "#cacaca", dateColor: "#b01011" },
     dark: { textColor: "#d4d4d4", bgColor: "#555555", dateColor: "#ff7475" }
@@ -68,6 +74,11 @@ export class Settings {
         miniWarning: "#d7aa57",
         miniSuccess: "#62b665",
         miniOther: "#777777"
+    };
+    timeUntilDeadline: SettingsTimeUntilDeadline = {
+        dangerHours: 24,
+        warningDays: 5,
+        middleDays: 14
     };
 
     setFetchtime(fetchTime: FetchTime) {


### PR DESCRIPTION
# Pull Request Template

## Description
課題の提出期限による色分けの基準を変更できるようにした
今までは(デフォルト色で)赤色のタブは24時間、黄色は5日間など固定されていたが、これを詳細設定から任意の時間に変更できるようにしました。

## Type of change

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## Levels of review
- [ ] Level1: 即ApproveしてOK
- [ ] Level2: 軽く目を通して問題がなければApprove
- [x] Level3: 実際にビルドして動作確認をしてほしい