### PR TITLE
Changed maximum of favorite courses to 100

### DIFF
--- a/src/features/favorite/index.ts
+++ b/src/features/favorite/index.ts
@@ -4,7 +4,7 @@ import { getCourseSiteID } from "../../utils";
  * Limit maximum number of course sites
  * @type {int}
  */
-const MAX_FAVORITES = 20;
+const MAX_FAVORITES = 100;
 
 const getSiteIdAndHrefSiteNameMap = (): Map<string, { href: string, title: string }> => {
     const sites = document.querySelectorAll(".fav-sites-entry");


### PR DESCRIPTION
# Pull Request Template

## Description
お気に入りタブの表示数の上限を20から100に増やしました。

## Type of change

- [ ] バグ修正
- [ ] 新機能
- [x] その他

## Levels of review
- [x] Level1: 即ApproveしてOK
- [ ] Level2: 軽く目を通して問題がなければApprove
- [ ] Level3: 実際にビルドして動作確認をしてほしい